### PR TITLE
configure.ac: Use AC_USE_SYSTEM_EXTENSIONS

### DIFF
--- a/backend/fbio.c
+++ b/backend/fbio.c
@@ -17,6 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <config.h>
+
 #include <glib.h>
 
 #include <errno.h>

--- a/backend/fbshell.c
+++ b/backend/fbshell.c
@@ -17,6 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <config.h>
+
 #include <glib.h>
 
 #define _XOPEN_SOURCE

--- a/backend/fbshellman.c
+++ b/backend/fbshellman.c
@@ -17,6 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <config.h>
+
 #include <glib.h>
 
 #include <string.h>

--- a/backend/fbterm.c
+++ b/backend/fbterm.c
@@ -17,6 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <config.h>
+
 #include <glib.h>
 
 #include <linux/kdev_t.h> /* MINOR() */

--- a/backend/fbtty.c
+++ b/backend/fbtty.c
@@ -17,6 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <config.h>
+
 #include <glib.h>
 
 #include <linux/kd.h>

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_INIT([ibus-fbterm], [1.0.1],
         [ibus-fbterm])
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([config.h])
+AC_USE_SYSTEM_EXTENSIONS
 
 # Checks for programs.
 m4_pattern_allow([^AS_(VERSION|NANO)$])

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
+m4_pattern_allow([^AS_(VERSION|NANO)$])
 AS_VERSION
 AS_NANO
 AC_PROG_CC


### PR DESCRIPTION
And to make it effective, include <config.c> at the start of C files
(except those compiled from Vala).  This is necessary to obtain a
declaration of ptsname in <stdlib.h>.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
